### PR TITLE
Adds checkstyle

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,10 @@ The `pom.xml` examples are added to the main `pom.xml` file under `<plugins>..</
 
 == Mandatory plugins for java projects
 
+=== checkstyle
+
+Enforces certain coding standards, complements both `enforcer` and `formatter` plugins
+
 === enforcer
 
 The enforcer plugin forces certain standards in pom.xml

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -47,7 +47,10 @@ Documentation and further configuration for each check can be found https://chec
               <module name="EqualsHashCode"></module>
               <module name="FallThrough"></module>
               <module name="FinalClass"></module>
-              <module name="HiddenField"></module>
+              <module name="HiddenField">
+                <property name="ignoreConstructorParameter" value="true"></property>
+                <property name="ignoreSetter" value="true"></property>
+              </module>
               <module name="IllegalCatch"></module>
               <module name="IllegalImport"></module>
               <module name="IllegalThrows"></module>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -26,6 +26,9 @@ Documentation and further configuration for each check can be found https://chec
     <checkstyleRules>
       <module name="Checker">
         <module name="TreeWalker">
+          <!-- annotations -->
+          <module name="MissingDeprecated"></module>
+          <module name="MissingOverride"></module>
           <!-- block checks -->
           <module name="AvoidNestedBlocks">
             <property name="allowInSwitchCase" value="true"></property>
@@ -37,11 +40,18 @@ Documentation and further configuration for each check can be found https://chec
           <module name="NeedBraces"></module>
           <!-- class design -->
           <module name="FinalClass"></module>
+          <module name="MutableException"></module>
           <module name="OneTopLevelClass"></module>
+          <module name="VisibilityModifier"></module>
           <!-- coding -->
+          <module name="AvoidNoArgumentSuperConstructorCall"></module>
+          <module name="ConstructorsDeclarationGrouping"></module>
+          <module name="CovariantEquals"></module>
+          <module name="DeclarationOrder"></module>
           <module name="DefaultComesLast"></module>
           <module name="EmptyStatement"></module>
           <module name="EqualsAvoidNull"></module>
+          <module name="EqualsHashCode"></module>
           <module name="FallThrough"></module>
           <module name="FinalLocalVariable"></module>
           <module name="IllegalCatch"></module>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -54,8 +54,10 @@ Documentation and further configuration for each check can be found https://chec
           <module name="EqualsHashCode"></module>
           <module name="FallThrough"></module>
           <module name="FinalLocalVariable"></module>
+          <module name="HiddenField"></module>
           <module name="IllegalCatch"></module>
           <module name="IllegalThrows"></module>
+          <module name="IllegalToken"></module>
           <module name="IllegalType"></module>
           <module name="InnerAssignment"></module>
           <module name="MagicNumber"></module>
@@ -71,7 +73,11 @@ Documentation and further configuration for each check can be found https://chec
           <module name="OneStatementPerLine"></module>
           <module name="PackageDeclaration"></module>
           <module name="ParameterAssignment"></module>
-          <module name="RequireThis"></module>
+          <module name="RequireThis">
+            <property name="checkFields" value="false"></property>
+            <property name="checkMethods" value="false"></property>
+            <property name="validateOnlyOverlapping" value="true"></property>
+          </module>
           <module name="SimplifyBooleanReturn"></module>
           <module name="SimplifyBooleanExpression"></module>
           <module name="StringLiteralEquality"></module>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -2,6 +2,8 @@
 
 == Usage
 
+Enforces certain coding standards, complements both `enforcer` and `formatter` plugins.
+
 Checks are automatically done once included to project.
 
 You can manually test checkstyle rules with `mvn checkstyle:check`
@@ -70,7 +72,7 @@ Documentation and further configuration for each check can be found https://chec
           <module name="AvoidStarImport"></module>
           <module name="AvoidStaticImport"></module>
           <module name="IllegalImport"></module>
-          <!-- Miscellaneous -->
+          <!-- Miscellaneous, part of TreeWalker module -->
           <module name="ArrayTypeStyle"></module>
           <module name="NoCodeInFile"></module>
           <module name="OuterTypeFilename"></module>
@@ -79,7 +81,8 @@ Documentation and further configuration for each check can be found https://chec
           <module name="ClassMemberImpliedModifier"></module>
           <module name="InterfaceMemberImpliedModifier"></module>
         </module>
-        <!-- Miscellaneous -->
+        <!-- Miscellaneous, part of Checker module-->
+        <module name="NewlineAtEndOfFile"></module>
         <module name="UniqueProperties"></module>
       </module>
     </checkstyleRules>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -86,17 +86,22 @@ Documentation and further configuration for each check can be found https://chec
           <module name="SimplifyBooleanReturn"></module>
           <module name="SimplifyBooleanExpression"></module>
           <module name="StringLiteralEquality"></module>
+          <module name="SuperClone"></module>
+          <module name="SuperFinalize"></module>
           <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"></module>
           <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"></module>
           <module name="UnnecessarySemicolonInEnumeration"></module>
           <module name="UnnecessarySemicolonInTryWithResources"></module>
           <module name="UnusedLocalVariable"></module>
+          <module name="VariableDeclarationUsageDistance"></module>
           <!-- imports -->
           <module name="AvoidStarImport"></module>
           <module name="AvoidStaticImport"></module>
           <module name="IllegalImport"></module>
+          <module name="RedundantImport"></module>
           <!-- Miscellaneous, part of TreeWalker module -->
           <module name="ArrayTypeStyle"></module>
+          <module name="FinalParameters"></module>
           <module name="NoCodeInFile"></module>
           <module name="OuterTypeFilename"></module>
           <module name="UpperEll"></module>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -66,6 +66,11 @@ Documentation and further configuration for each check can be found https://chec
             <property name="skipEnhancedForLoopVariable" value="true"></property>
           </module>
           <module name="MultipleVariableDeclarations"></module>
+          <module name="NestedForDepth">
+            <property name="max" value="1"/>
+          </module>
+          <module name="NestedIfDepth"></module>
+          <module name="NestedTryDepth"></module>
           <module name="NoArrayTrailingComma"></module>
           <module name="NoClone"></module>
           <module name="NoEnumTrailingComma"></module>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -108,9 +108,17 @@ Documentation and further configuration for each check can be found https://chec
           <!-- modifiers -->
           <module name="ClassMemberImpliedModifier"></module>
           <module name="InterfaceMemberImpliedModifier"></module>
+          <module name="ModifierOrder"></module>
+          <!-- naming conventions -->
+          <module name="PackageName">
+            <property name="format" value="^com\.teragrep\.[a-z]{3}_\d{2}(.[a-zA-Z]\w*)*$"/>
+          </module>
+          <module name="TypeName"></module>
         </module>
         <!-- Miscellaneous, part of Checker module-->
         <module name="NewlineAtEndOfFile"></module>
+        <module name="OrderedProperties"></module>
+        <module name="Translation"></module>
         <module name="UniqueProperties"></module>
       </module>
     </checkstyleRules>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -4,11 +4,11 @@
 
 Enforces certain coding standards, complements both `enforcer` and `formatter` plugins.
 
+First set of rules inside `scan-errors` will always fail the build if found, and `scan-warnings` will just warn.
+
 Focuses on best practices for code and not stylistic formatting as that is done by `formatter` plugin.
 
 Checks are automatically done once included to project.
-
-You can manually test checkstyle rules with `mvn checkstyle:check`
 
 Documentation and further configuration for each check can be found https://checkstyle.org/checks.html[in their documentation]
 
@@ -22,8 +22,9 @@ Documentation and further configuration for each check can be found https://chec
   <artifactId>maven-checkstyle-plugin</artifactId>
   <version>3.5.0</version>
   <executions>
+    <!-- These are all errors that will fail the build if triggered -->
     <execution>
-      <id>verify-style-errors</id>
+      <id>scan-errors</id>
       <goals>
         <goal>check</goal>
       </goals>
@@ -36,103 +37,62 @@ Documentation and further configuration for each check can be found https://chec
         <checkstyleRules>
           <module name="Checker">
             <module name="TreeWalker">
-              <!-- annotations -->
-              <module name="MissingDeprecated"></module>
-              <module name="MissingOverride"></module>
-              <!-- block checks -->
-              <module name="AvoidNestedBlocks">
-                <property name="allowInSwitchCase" value="true"></property>
-              </module>
-              <module name="EmptyBlock">
-                <property name="option" value="text"></property>
-              </module>
-              <module name="EmptyCatchBlock"></module>
-              <module name="NeedBraces"></module>
-              <!-- class design -->
-              <module name="FinalClass"></module>
-              <module name="MutableException"></module>
-              <module name="OneTopLevelClass"></module>
-              <module name="VisibilityModifier"></module>
-              <!-- coding -->
-              <module name="AvoidNoArgumentSuperConstructorCall"></module>
+              <module name="ClassMemberImpliedModifier"></module>
               <module name="CovariantEquals"></module>
-              <module name="DeclarationOrder"></module>
               <module name="DefaultComesLast"></module>
+              <module name="EmptyBlock"></module>
+              <module name="EmptyCatchBlock"></module>
               <module name="EmptyStatement"></module>
               <module name="EqualsAvoidNull"></module>
               <module name="EqualsHashCode"></module>
               <module name="FallThrough"></module>
+              <module name="FinalClass"></module>
               <module name="HiddenField"></module>
               <module name="IllegalCatch"></module>
+              <module name="IllegalImport"></module>
               <module name="IllegalThrows"></module>
               <module name="IllegalToken"></module>
               <module name="IllegalType"></module>
               <module name="InnerAssignment"></module>
+              <module name="InterfaceMemberImpliedModifier"></module>
+              <module name="MissingOverride"></module>
               <module name="MissingSwitchDefault"></module>
               <module name="ModifiedControlVariable">
                 <property name="skipEnhancedForLoopVariable" value="true"></property>
               </module>
-              <module name="MultipleVariableDeclarations"></module>
-              <module name="NestedForDepth">
-                <property name="max" value="1"></property>
-              </module>
-              <module name="NestedIfDepth"></module>
-              <module name="NestedTryDepth"></module>
-              <module name="NoArrayTrailingComma"></module>
-              <module name="NoClone"></module>
-              <module name="NoEnumTrailingComma"></module>
-              <module name="NoFinalizer"></module>
-              <module name="OneStatementPerLine"></module>
-              <module name="PackageDeclaration"></module>
-              <module name="ParameterAssignment"></module>
-              <module name="RequireThis">
-                <property name="checkFields" value="false"></property>
-                <property name="checkMethods" value="false"></property>
-                <property name="validateOnlyOverlapping" value="true"></property>
-              </module>
-              <module name="SimplifyBooleanReturn"></module>
-              <module name="SimplifyBooleanExpression"></module>
-              <module name="StringLiteralEquality"></module>
-              <module name="SuperClone"></module>
-              <module name="SuperFinalize"></module>
-              <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"></module>
-              <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"></module>
-              <module name="UnnecessarySemicolonInEnumeration"></module>
-              <module name="UnnecessarySemicolonInTryWithResources"></module>
-              <module name="UnusedLocalVariable"></module>
-              <module name="VariableDeclarationUsageDistance"></module>
-              <!-- imports -->
-              <module name="AvoidStarImport"></module>
-              <module name="AvoidStaticImport"></module>
-              <module name="IllegalImport"></module>
-              <module name="RedundantImport"></module>
-              <!-- Miscellaneous, part of TreeWalker module -->
-              <module name="ArrayTypeStyle"></module>
-              <module name="FinalParameters"></module>
-              <module name="NoCodeInFile"></module>
-              <module name="OuterTypeFilename"></module>
-              <module name="UpperEll"></module>
-              <!-- modifiers -->
-              <module name="ClassMemberImpliedModifier"></module>
-              <module name="InterfaceMemberImpliedModifier"></module>
               <module name="ModifierOrder"></module>
-              <!-- naming conventions -->
+              <module name="MutableException"></module>
+              <module name="NeedBraces"></module>
+              <module name="NestedForDepth">
+                <property name="max" value="2"></property>
+              </module>
+              <module name="NestedTryDepth"></module>
+              <module name="NoClone"></module>
+              <module name="NoFinalizer"></module>
+              <module name="OneTopLevelClass"></module>
+              <module name="PackageDeclaration"></module>
               <module name="PackageName">
                 <property name="format" value="^com\.teragrep\.[a-z]{3}_\d{2}(.[a-zA-Z]\w*)*$"></property>
               </module>
+              <module name="ReturnCount">
+                <property name="max" value="5"></property>
+              </module>
+              <module name="StringLiteralEquality"></module>
+              <module name="SuperClone"></module>
+              <module name="SuperFinalize"></module>
               <module name="TypeName"></module>
+              <module name="UpperEll"></module>
+              <module name="VisibilityModifier"></module>
             </module>
-            <!-- Miscellaneous, part of Checker module-->
-            <module name="NewlineAtEndOfFile"></module>
-            <module name="OrderedProperties"></module>
             <module name="Translation"></module>
             <module name="UniqueProperties"></module>
           </module>
         </checkstyleRules>
       </configuration>
     </execution>
+    <!-- These are warnings but will not fail the build -->
     <execution>
-      <id>verify-style-warnings</id>
+      <id>scan-warnings</id>
       <goals>
         <goal>check</goal>
       </goals>
@@ -145,16 +105,108 @@ Documentation and further configuration for each check can be found https://chec
         <checkstyleRules>
           <module name="Checker">
             <module name="TreeWalker">
+              <module name="ArrayTypeStyle">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="AvoidNestedBlocks">
+                <property name="allowInSwitchCase" value="true"></property>
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="AvoidNoArgumentSuperConstructorCall">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="AvoidStarImport">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="AvoidStaticImport">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="DeclarationOrder">
+                <property name="severity" value="warning"></property>
+              </module>
               <module name="FinalLocalVariable">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="FinalParameters">
                 <property name="severity" value="warning"></property>
               </module>
               <module name="MagicNumber">
                 <property name="severity" value="warning"></property>
               </module>
-              <module name="ReturnCount">
+              <module name="MissingDeprecated">
                 <property name="severity" value="warning"></property>
-                <property name="max" value="5"></property>
               </module>
+              <module name="MultipleVariableDeclarations">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="NestedForDepth">
+                <property name="max" value="1"></property>
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="NestedIfDepth">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="NoArrayTrailingComma">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="NoCodeInFile">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="NoEnumTrailingComma">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="OneStatementPerLine">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="OuterTypeFilename">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="ParameterAssignment">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="RedundantImport">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="RequireThis">
+                <property name="checkFields" value="false"></property>
+                <property name="checkMethods" value="false"></property>
+                <property name="validateOnlyOverlapping" value="true"></property>
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="ReturnCount">
+                <property name="max" value="1"></property>
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="SimplifyBooleanExpression">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="SimplifyBooleanReturn">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="UnnecessarySemicolonAfterOuterTypeDeclaration">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="UnnecessarySemicolonAfterTypeMemberDeclaration">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="UnnecessarySemicolonInEnumeration">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="UnnecessarySemicolonInTryWithResources">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="UnusedLocalVariable">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="VariableDeclarationUsageDistance">
+                <property name="severity" value="warning"></property>
+              </module>
+            </module>
+            <module name="NewlineAtEndOfFile">
+                <property name="severity" value="warning"></property>
+            </module>
+            <module name="OrderedProperties">
+                <property name="severity" value="warning"></property>
             </module>
           </module>
         </checkstyleRules>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -1,0 +1,97 @@
+= checkstyle plugin
+
+== Usage
+
+Checks are automatically done once included to project.
+
+You can manually test checkstyle rules with `mvn checkstyle:check`
+
+Documentation and further configuration for each check can be found https://checkstyle.org/checks.html[in their documentation]
+
+=== Add the following to pom.xml
+
+.pom.xml
+[source,xml]
+----
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-checkstyle-plugin</artifactId>
+  <version>3.5.0</version>
+  <configuration>
+    <logViolationsToConsole>true</logViolationsToConsole>
+    <checkstyleRules>
+      <module name="Checker">
+        <module name="TreeWalker">
+          <!-- block checks -->
+          <module name="AvoidNestedBlocks">
+            <property name="allowInSwitchCase" value="true"></property>
+          </module>
+          <module name="EmptyBlock">
+            <property name="option" value="text"></property>
+          </module>
+          <module name="EmptyCatchBlock"></module>
+          <module name="NeedBraces"></module>
+          <!-- class design -->
+          <module name="FinalClass"></module>
+          <module name="OneTopLevelClass"></module>
+          <!-- coding -->
+          <module name="DefaultComesLast"></module>
+          <module name="EmptyStatement"></module>
+          <module name="EqualsAvoidNull"></module>
+          <module name="FallThrough"></module>
+          <module name="FinalLocalVariable"></module>
+          <module name="IllegalCatch"></module>
+          <module name="IllegalThrows"></module>
+          <module name="IllegalType"></module>
+          <module name="InnerAssignment"></module>
+          <module name="MagicNumber"></module>
+          <module name="MissingSwitchDefault"></module>
+          <module name="ModifiedControlVariable">
+            <property name="skipEnhancedForLoopVariable" value="true"></property>
+          </module>
+          <module name="MultipleVariableDeclarations"></module>
+          <module name="NoArrayTrailingComma"></module>
+          <module name="NoClone"></module>
+          <module name="NoEnumTrailingComma"></module>
+          <module name="NoFinalizer"></module>
+          <module name="OneStatementPerLine"></module>
+          <module name="PackageDeclaration"></module>
+          <module name="ParameterAssignment"></module>
+          <module name="RequireThis"></module>
+          <module name="SimplifyBooleanReturn"></module>
+          <module name="SimplifyBooleanExpression"></module>
+          <module name="StringLiteralEquality"></module>
+          <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"></module>
+          <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"></module>
+          <module name="UnnecessarySemicolonInEnumeration"></module>
+          <module name="UnnecessarySemicolonInTryWithResources"></module>
+          <module name="UnusedLocalVariable"></module>
+          <!-- imports -->
+          <module name="AvoidStarImport"></module>
+          <module name="AvoidStaticImport"></module>
+          <module name="IllegalImport"></module>
+          <!-- Miscellaneous -->
+          <module name="ArrayTypeStyle"></module>
+          <module name="NoCodeInFile"></module>
+          <module name="OuterTypeFilename"></module>
+          <module name="UpperEll"></module>
+          <!-- modifiers -->
+          <module name="ClassMemberImpliedModifier"></module>
+          <module name="InterfaceMemberImpliedModifier"></module>
+        </module>
+        <!-- Miscellaneous -->
+        <module name="UniqueProperties"></module>
+      </module>
+    </checkstyleRules>
+  </configuration>
+  <executions>
+    <execution>
+      <id>verify-style</id>
+      <goals>
+        <goal>check</goal>
+      </goals>
+      <phase>process-classes</phase>
+    </execution>
+  </executions>
+</plugin>
+----

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -22,7 +22,11 @@ Documentation and further configuration for each check can be found https://chec
   <artifactId>maven-checkstyle-plugin</artifactId>
   <version>3.5.0</version>
   <configuration>
+    <!-- Turn violationSeverity to warning to enable stricter checks -->
+    <violationSeverity>error</violationSeverity>
     <logViolationsToConsole>true</logViolationsToConsole>
+    <failOnViolation>true</failOnViolation>
+    <failsOnError>false</failsOnError>
     <checkstyleRules>
       <module name="Checker">
         <module name="TreeWalker">
@@ -52,14 +56,18 @@ Documentation and further configuration for each check can be found https://chec
           <module name="EqualsAvoidNull"></module>
           <module name="EqualsHashCode"></module>
           <module name="FallThrough"></module>
-          <module name="FinalLocalVariable"></module>
+          <module name="FinalLocalVariable">
+            <property name="severity" value="warning"></property>
+          </module>
           <module name="HiddenField"></module>
           <module name="IllegalCatch"></module>
           <module name="IllegalThrows"></module>
           <module name="IllegalToken"></module>
           <module name="IllegalType"></module>
           <module name="InnerAssignment"></module>
-          <module name="MagicNumber"></module>
+          <module name="MagicNumber">
+            <property name="severity" value="warning"></property>
+          </module>
           <module name="MissingSwitchDefault"></module>
           <module name="ModifiedControlVariable">
             <property name="skipEnhancedForLoopVariable" value="true"></property>
@@ -81,6 +89,10 @@ Documentation and further configuration for each check can be found https://chec
             <property name="checkFields" value="false"></property>
             <property name="checkMethods" value="false"></property>
             <property name="validateOnlyOverlapping" value="true"></property>
+          </module>
+          <module name="ReturnCount">
+            <property name="severity" value="warning"></property>
+            <property name="max" value="5"/>
           </module>
           <module name="SimplifyBooleanReturn"></module>
           <module name="SimplifyBooleanExpression"></module>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -72,7 +72,7 @@ Documentation and further configuration for each check can be found https://chec
               <module name="OneTopLevelClass"></module>
               <module name="PackageDeclaration"></module>
               <module name="PackageName">
-                <property name="format" value="^com\.teragrep\.[a-z]{3}_?\d{2}(?:.[a-zA-Z]\w*)*$"></property>
+                <property name="format" value="^com\.teragrep\.[a-z]{3}_\d{2}(?:.[a-zA-Z]\w*)*$"></property>
               </module>
               <module name="ReturnCount">
                 <property name="max" value="5"></property>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -45,7 +45,6 @@ Documentation and further configuration for each check can be found https://chec
           <module name="VisibilityModifier"></module>
           <!-- coding -->
           <module name="AvoidNoArgumentSuperConstructorCall"></module>
-          <module name="ConstructorsDeclarationGrouping"></module>
           <module name="CovariantEquals"></module>
           <module name="DeclarationOrder"></module>
           <module name="DefaultComesLast"></module>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -4,6 +4,8 @@
 
 Enforces certain coding standards, complements both `enforcer` and `formatter` plugins.
 
+Focuses on best practices for code and not stylistic formatting as that is done by `formatter` plugin.
+
 Checks are automatically done once included to project.
 
 You can manually test checkstyle rules with `mvn checkstyle:check`

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -72,7 +72,7 @@ Documentation and further configuration for each check can be found https://chec
               <module name="OneTopLevelClass"></module>
               <module name="PackageDeclaration"></module>
               <module name="PackageName">
-                <property name="format" value="^com\.teragrep\.[a-z]{3}_\d{2}(.[a-zA-Z]\w*)*$"></property>
+                <property name="format" value="^com\.teragrep\.[a-z]{3}_?\d{2}(?:.[a-zA-Z]\w*)*$"></property>
               </module>
               <module name="ReturnCount">
                 <property name="max" value="5"></property>

--- a/checkstyle/README.adoc
+++ b/checkstyle/README.adoc
@@ -21,126 +21,144 @@ Documentation and further configuration for each check can be found https://chec
   <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-checkstyle-plugin</artifactId>
   <version>3.5.0</version>
-  <configuration>
-    <!-- Turn violationSeverity to warning to enable stricter checks -->
-    <violationSeverity>error</violationSeverity>
-    <logViolationsToConsole>true</logViolationsToConsole>
-    <failOnViolation>true</failOnViolation>
-    <failsOnError>false</failsOnError>
-    <checkstyleRules>
-      <module name="Checker">
-        <module name="TreeWalker">
-          <!-- annotations -->
-          <module name="MissingDeprecated"></module>
-          <module name="MissingOverride"></module>
-          <!-- block checks -->
-          <module name="AvoidNestedBlocks">
-            <property name="allowInSwitchCase" value="true"></property>
-          </module>
-          <module name="EmptyBlock">
-            <property name="option" value="text"></property>
-          </module>
-          <module name="EmptyCatchBlock"></module>
-          <module name="NeedBraces"></module>
-          <!-- class design -->
-          <module name="FinalClass"></module>
-          <module name="MutableException"></module>
-          <module name="OneTopLevelClass"></module>
-          <module name="VisibilityModifier"></module>
-          <!-- coding -->
-          <module name="AvoidNoArgumentSuperConstructorCall"></module>
-          <module name="CovariantEquals"></module>
-          <module name="DeclarationOrder"></module>
-          <module name="DefaultComesLast"></module>
-          <module name="EmptyStatement"></module>
-          <module name="EqualsAvoidNull"></module>
-          <module name="EqualsHashCode"></module>
-          <module name="FallThrough"></module>
-          <module name="FinalLocalVariable">
-            <property name="severity" value="warning"></property>
-          </module>
-          <module name="HiddenField"></module>
-          <module name="IllegalCatch"></module>
-          <module name="IllegalThrows"></module>
-          <module name="IllegalToken"></module>
-          <module name="IllegalType"></module>
-          <module name="InnerAssignment"></module>
-          <module name="MagicNumber">
-            <property name="severity" value="warning"></property>
-          </module>
-          <module name="MissingSwitchDefault"></module>
-          <module name="ModifiedControlVariable">
-            <property name="skipEnhancedForLoopVariable" value="true"></property>
-          </module>
-          <module name="MultipleVariableDeclarations"></module>
-          <module name="NestedForDepth">
-            <property name="max" value="1"/>
-          </module>
-          <module name="NestedIfDepth"></module>
-          <module name="NestedTryDepth"></module>
-          <module name="NoArrayTrailingComma"></module>
-          <module name="NoClone"></module>
-          <module name="NoEnumTrailingComma"></module>
-          <module name="NoFinalizer"></module>
-          <module name="OneStatementPerLine"></module>
-          <module name="PackageDeclaration"></module>
-          <module name="ParameterAssignment"></module>
-          <module name="RequireThis">
-            <property name="checkFields" value="false"></property>
-            <property name="checkMethods" value="false"></property>
-            <property name="validateOnlyOverlapping" value="true"></property>
-          </module>
-          <module name="ReturnCount">
-            <property name="severity" value="warning"></property>
-            <property name="max" value="5"/>
-          </module>
-          <module name="SimplifyBooleanReturn"></module>
-          <module name="SimplifyBooleanExpression"></module>
-          <module name="StringLiteralEquality"></module>
-          <module name="SuperClone"></module>
-          <module name="SuperFinalize"></module>
-          <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"></module>
-          <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"></module>
-          <module name="UnnecessarySemicolonInEnumeration"></module>
-          <module name="UnnecessarySemicolonInTryWithResources"></module>
-          <module name="UnusedLocalVariable"></module>
-          <module name="VariableDeclarationUsageDistance"></module>
-          <!-- imports -->
-          <module name="AvoidStarImport"></module>
-          <module name="AvoidStaticImport"></module>
-          <module name="IllegalImport"></module>
-          <module name="RedundantImport"></module>
-          <!-- Miscellaneous, part of TreeWalker module -->
-          <module name="ArrayTypeStyle"></module>
-          <module name="FinalParameters"></module>
-          <module name="NoCodeInFile"></module>
-          <module name="OuterTypeFilename"></module>
-          <module name="UpperEll"></module>
-          <!-- modifiers -->
-          <module name="ClassMemberImpliedModifier"></module>
-          <module name="InterfaceMemberImpliedModifier"></module>
-          <module name="ModifierOrder"></module>
-          <!-- naming conventions -->
-          <module name="PackageName">
-            <property name="format" value="^com\.teragrep\.[a-z]{3}_\d{2}(.[a-zA-Z]\w*)*$"/>
-          </module>
-          <module name="TypeName"></module>
-        </module>
-        <!-- Miscellaneous, part of Checker module-->
-        <module name="NewlineAtEndOfFile"></module>
-        <module name="OrderedProperties"></module>
-        <module name="Translation"></module>
-        <module name="UniqueProperties"></module>
-      </module>
-    </checkstyleRules>
-  </configuration>
   <executions>
     <execution>
-      <id>verify-style</id>
+      <id>verify-style-errors</id>
       <goals>
         <goal>check</goal>
       </goals>
       <phase>process-classes</phase>
+      <configuration>
+        <violationSeverity>error</violationSeverity>
+        <logViolationsToConsole>true</logViolationsToConsole>
+        <failOnViolation>true</failOnViolation>
+        <failsOnError>false</failsOnError>
+        <checkstyleRules>
+          <module name="Checker">
+            <module name="TreeWalker">
+              <!-- annotations -->
+              <module name="MissingDeprecated"></module>
+              <module name="MissingOverride"></module>
+              <!-- block checks -->
+              <module name="AvoidNestedBlocks">
+                <property name="allowInSwitchCase" value="true"></property>
+              </module>
+              <module name="EmptyBlock">
+                <property name="option" value="text"></property>
+              </module>
+              <module name="EmptyCatchBlock"></module>
+              <module name="NeedBraces"></module>
+              <!-- class design -->
+              <module name="FinalClass"></module>
+              <module name="MutableException"></module>
+              <module name="OneTopLevelClass"></module>
+              <module name="VisibilityModifier"></module>
+              <!-- coding -->
+              <module name="AvoidNoArgumentSuperConstructorCall"></module>
+              <module name="CovariantEquals"></module>
+              <module name="DeclarationOrder"></module>
+              <module name="DefaultComesLast"></module>
+              <module name="EmptyStatement"></module>
+              <module name="EqualsAvoidNull"></module>
+              <module name="EqualsHashCode"></module>
+              <module name="FallThrough"></module>
+              <module name="HiddenField"></module>
+              <module name="IllegalCatch"></module>
+              <module name="IllegalThrows"></module>
+              <module name="IllegalToken"></module>
+              <module name="IllegalType"></module>
+              <module name="InnerAssignment"></module>
+              <module name="MissingSwitchDefault"></module>
+              <module name="ModifiedControlVariable">
+                <property name="skipEnhancedForLoopVariable" value="true"></property>
+              </module>
+              <module name="MultipleVariableDeclarations"></module>
+              <module name="NestedForDepth">
+                <property name="max" value="1"></property>
+              </module>
+              <module name="NestedIfDepth"></module>
+              <module name="NestedTryDepth"></module>
+              <module name="NoArrayTrailingComma"></module>
+              <module name="NoClone"></module>
+              <module name="NoEnumTrailingComma"></module>
+              <module name="NoFinalizer"></module>
+              <module name="OneStatementPerLine"></module>
+              <module name="PackageDeclaration"></module>
+              <module name="ParameterAssignment"></module>
+              <module name="RequireThis">
+                <property name="checkFields" value="false"></property>
+                <property name="checkMethods" value="false"></property>
+                <property name="validateOnlyOverlapping" value="true"></property>
+              </module>
+              <module name="SimplifyBooleanReturn"></module>
+              <module name="SimplifyBooleanExpression"></module>
+              <module name="StringLiteralEquality"></module>
+              <module name="SuperClone"></module>
+              <module name="SuperFinalize"></module>
+              <module name="UnnecessarySemicolonAfterOuterTypeDeclaration"></module>
+              <module name="UnnecessarySemicolonAfterTypeMemberDeclaration"></module>
+              <module name="UnnecessarySemicolonInEnumeration"></module>
+              <module name="UnnecessarySemicolonInTryWithResources"></module>
+              <module name="UnusedLocalVariable"></module>
+              <module name="VariableDeclarationUsageDistance"></module>
+              <!-- imports -->
+              <module name="AvoidStarImport"></module>
+              <module name="AvoidStaticImport"></module>
+              <module name="IllegalImport"></module>
+              <module name="RedundantImport"></module>
+              <!-- Miscellaneous, part of TreeWalker module -->
+              <module name="ArrayTypeStyle"></module>
+              <module name="FinalParameters"></module>
+              <module name="NoCodeInFile"></module>
+              <module name="OuterTypeFilename"></module>
+              <module name="UpperEll"></module>
+              <!-- modifiers -->
+              <module name="ClassMemberImpliedModifier"></module>
+              <module name="InterfaceMemberImpliedModifier"></module>
+              <module name="ModifierOrder"></module>
+              <!-- naming conventions -->
+              <module name="PackageName">
+                <property name="format" value="^com\.teragrep\.[a-z]{3}_\d{2}(.[a-zA-Z]\w*)*$"></property>
+              </module>
+              <module name="TypeName"></module>
+            </module>
+            <!-- Miscellaneous, part of Checker module-->
+            <module name="NewlineAtEndOfFile"></module>
+            <module name="OrderedProperties"></module>
+            <module name="Translation"></module>
+            <module name="UniqueProperties"></module>
+          </module>
+        </checkstyleRules>
+      </configuration>
+    </execution>
+    <execution>
+      <id>verify-style-warnings</id>
+      <goals>
+        <goal>check</goal>
+      </goals>
+      <phase>process-classes</phase>
+      <configuration>
+        <violationSeverity>warning</violationSeverity>
+        <logViolationsToConsole>true</logViolationsToConsole>
+        <failOnViolation>false</failOnViolation>
+        <failsOnError>false</failsOnError>
+        <checkstyleRules>
+          <module name="Checker">
+            <module name="TreeWalker">
+              <module name="FinalLocalVariable">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="MagicNumber">
+                <property name="severity" value="warning"></property>
+              </module>
+              <module name="ReturnCount">
+                <property name="severity" value="warning"></property>
+                <property name="max" value="5"></property>
+              </module>
+            </module>
+          </module>
+        </checkstyleRules>
+      </configuration>
     </execution>
   </executions>
 </plugin>


### PR DESCRIPTION
This is WIP as not all check categories have been sanity checked and some checks might need to be added/removed from the current list as some stuff like `MagicNumbers` can be very painful to deal with

The following check subcategories have not yet been checked:

https://checkstyle.org/checks/annotation/index.html - might have no need?

https://checkstyle.org/checks/header/index.html - Enforced already by formatter plugin

https://checkstyle.org/checks/javadoc/index.html - These might be good to add

https://checkstyle.org/checks/metrics/index.html - Questionable

https://checkstyle.org/checks/naming/index.html - These require a lot of thought, might be good idea to add in a new PR if adding it?

https://checkstyle.org/checks/regexp/index.html - Might be good to add stuff like checking for `System.out.println` and such calls

https://checkstyle.org/checks/sizes/index.html - Also questionable as some of the checks comes from human code reviews

https://checkstyle.org/checks/whitespace/index.html - Should be enforced by formatter already
