### PR TITLE
Add com.teragrep:*:0.0.1-SNAPSHOT to allowed dynamic versions

### DIFF
--- a/enforcer/README.adoc
+++ b/enforcer/README.adoc
@@ -77,7 +77,12 @@ We do not support third party repositories by default due to code management and
           <requireJavaVersion>
             <version>[1.8,1.9)</version>
           </requireJavaVersion>
-          <banDynamicVersions/>
+          <banDynamicVersions>
+            <ignores>
+              <!-- Allow only local development builds by default -->
+              <ignore>com.teragrep:*:0.0.1-SNAPSHOT</ignore>
+            </ignores>
+          </banDynamicVersions>
           <requirePluginVersions>
             <message>All plugins are required to contain specific version.</message>
             <unCheckedPluginList>org.apache.maven.plugins:maven-site-plugin,org.apache.maven.plugins:maven-resources-plugin,org.apache.maven.plugins:maven-clean-plugin,org.apache.maven.plugins:maven-install-plugin,org.apache.maven.plugins:maven-deploy-plugin,org.apache.maven.plugins:maven-compiler-plugin,org.apache.maven.plugins:maven-jar-plugin</unCheckedPluginList>


### PR DESCRIPTION
Fixes #25

This enables locally building and installing pth_06 -> pth_10 -> pth_07 chain for example while blocking other dynamic versions