### PR TITLE
Adds cache-apt-pkgs-action by awalsh128 for Doxygen dependencies

### DIFF
--- a/.github/workflows/publish_pages_from_docs.yaml
+++ b/.github/workflows/publish_pages_from_docs.yaml
@@ -41,9 +41,10 @@ jobs:
         run: mvn -B javadoc:aggregate
         env:
           MAVEN_OPTS: "-Dmaven.javadoc.failOnError=false"
-      # Install dependencies
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install doxygen graphviz plantuml
+      # Install or restore dependencies from caches
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: doxygen graphviz plantuml
       # Generate doxygen docs
       - name: Generate Doxygen docs
         run: doxygen Doxyfile

--- a/workflows/publish_pages_from_docs.yaml
+++ b/workflows/publish_pages_from_docs.yaml
@@ -35,9 +35,10 @@ jobs:
         run: mvn -B javadoc:aggregate
         env:
           MAVEN_OPTS: "-Dmaven.javadoc.failOnError=false"
-      # Install dependencies
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install doxygen graphviz plantuml
+      # Install or restore dependencies from caches
+      - uses: awalsh128/cache-apt-pkgs-action@v1.5.3
+        with:
+          packages: doxygen graphviz plantuml
       # Generate doxygen docs
       - name: Generate Doxygen docs
         run: doxygen Doxyfile


### PR DESCRIPTION
The [action itself](https://github.com/marketplace/actions/cache-apt-packages) looks relatively trustworthy based on amount of stars received in the main repo: https://github.com/awalsh128/cache-apt-pkgs-action
It also seems to use https://github.com/ilikenwf/apt-fast/ behind the scenes and it seems trustworthy project as well.

Normal run before: `2m 43s`
First run run that builds the caches: `4m 13s`
Next run with packages from caches: `56s`

This action could be further leveraged in other projects to speed up building time if necessary